### PR TITLE
Force numeric context for 'expires_in'.

### DIFF
--- a/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/AuthorizationCode.pm
@@ -62,7 +62,7 @@ sub handle_request {
         access_token => $access_token->token,
     };
 
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/ClientCredentials.pm
@@ -43,7 +43,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/ExternalService.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/ExternalService.pm
@@ -52,7 +52,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/GroupingRefreshToken.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/GroupingRefreshToken.pm
@@ -70,7 +70,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/Password.pm
@@ -52,7 +52,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/RefreshToken.pm
@@ -42,7 +42,7 @@ sub handle_request {
         token_type => 'Bearer',
         access_token => $access_token->token,
     };
-    $res->{expires_in} = $access_token->expires_in
+    $res->{expires_in} = int($access_token->expires_in)
         if $access_token->expires_in;
     $res->{refresh_token} = $auth_info->refresh_token
         if $auth_info->refresh_token;

--- a/lib/OAuth/Lite2/Server/GrantHandler/ServerState.pm
+++ b/lib/OAuth/Lite2/Server/GrantHandler/ServerState.pm
@@ -31,7 +31,7 @@ sub handle_request {
 
     my $res = {
         server_state    => $server_state->server_state,
-        expires_in      => $server_state->expires_in
+        expires_in      => int($server_state->expires_in),
     };
     return $res;
 }


### PR DESCRIPTION
Depending on where the expiration value comes from, the JSON encoder may
consider this numeric value as a string and thus add quotes around it.

All examples in the RFC6749 show that thevalue should not be quoted and
some clients (if they do some type enforcing) will generate an error
when parsing a quoted value.

Rather than do some post-processing at the application layer, make the
OAuth::Lite2 library force the numerical context for the value.